### PR TITLE
Make overlapping keywords highlight

### DIFF
--- a/src/keyword-mark.ts
+++ b/src/keyword-mark.ts
@@ -125,7 +125,12 @@ export class KeywordMarkElement extends HTMLElement {
     }
 
     const lowerText = text.toLowerCase();
-    const terms = keywords.toLowerCase().split(delimiter);
+    const terms = keywords
+      .toLowerCase()
+      .split(delimiter)
+      .sort((a, b) => {
+        return b.length - a.length;
+      });
     const splitPattern = new RegExp(
       `${terms.map(escapeRegex).join('|')}`,
       'gi',

--- a/src/test/keyword-mark_test.ts
+++ b/src/test/keyword-mark_test.ts
@@ -178,4 +178,15 @@ describe('keyword-mark', () => {
       </style>
       <mark>[baz]</mark> one <mark>(bar)</mark> two <mark>foo?</mark> three`);
   });
+
+  it('should handle overlapping keywords', () => {
+    element.keywords = 'fo foo';
+    expect(element.shadowRoot!.innerHTML.trim()).to.equal(`<style>
+        mark {
+          color: var(--keyword-mark-color);
+          background: var(--keyword-mark-background, yellow);
+        }
+      </style>
+      <mark>foo</mark> BAR baz`);
+  });
 });


### PR DESCRIPTION
Fix for https://github.com/43081j/keyword-mark-element/issues/9